### PR TITLE
Fix: Windows request handler

### DIFF
--- a/torii_usb/usb/request/windows/__init__.py
+++ b/torii_usb/usb/request/windows/__init__.py
@@ -84,7 +84,7 @@ class WindowsRequestHandler(USBRequestHandler):
 			descriptorSetHandler.length.eq(setup.length),
 		]
 
-		with m.If(self.handlerCondition(setup)):
+		with m.If(self.handler_condition(setup)):
 			with m.FSM(domain = 'usb'):
 				# IDLE -- not handling any active request
 				with m.State('IDLE'):
@@ -145,7 +145,7 @@ class WindowsRequestHandler(USBRequestHandler):
 
 		return m
 
-	def handlerCondition(self, setup: SetupPacket):
+	def handler_condition(self, setup: SetupPacket):
 		''' Defines the setup packet conditions under which the request handler will operate.
 
 		This is used to gate the handler's operation and forms part of the condition under which

--- a/torii_usb/usb/request/windows/descriptorSet.py
+++ b/torii_usb/usb/request/windows/descriptorSet.py
@@ -233,7 +233,7 @@ class GetDescriptorSetHandler(Elaboratable):
 				m.d.comb += [
 					self.tx.valid.eq(1),
 					readPort.addr.eq(descriptorDataBaseAddress + wordInStream),
-					self.tx.data.eq(readPort.data.word_select(3 - byteInStream, 8)),
+					self.tx.data.eq(readPort.data.word_select((3 - byteInStream).as_unsigned(), 8)),
 					self.tx.first.eq(onFirstPacket),
 					self.tx.last.eq(onLastPacket),
 				]

--- a/torii_usb/usb/stream.py
+++ b/torii_usb/usb/stream.py
@@ -55,6 +55,8 @@ class USBOutStreamInterface(Record):
 		rx_valid  | next
 
 	'''
+	valid: Signal
+	next: Signal
 
 	def __init__(self, data_width = 8):
 		'''

--- a/torii_usb/usb/usb2/packet.py
+++ b/torii_usb/usb/usb2/packet.py
@@ -541,7 +541,7 @@ class USBDataPacketCRC(Elaboratable):
 		interface: DataCRCInterface
 			The interface to be added; accepts control signals from other modules, and
 			brings CRC output to them. This method can be called multiple times to generate
-			multiplpe CRCs.
+			multiple CRCs.
 		'''
 		self._interfaces.append(interface)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

In this PR we address a series of issues noticed when switching dragonBoot over from its own WindowsRequestHandler to the USB core's one.

This addresses it using an older format for the handler condition function, and a signed-unsigned conversion error in the descriptor set handler block.

When merged, this PR needs backporting to v0.8 and a release cutting as that release series is broken without this if trying to use the handler.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii USB [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii USB and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

## Relevant Issues/Pull Requests/Discussions

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CONTRIBUTING.md#ai-usage-policy
