### PR TITLE
Fix usage of `hasattr` on module submodules

### DIFF
--- a/torii_usb/usb/usb2/control.py
+++ b/torii_usb/usb/usb2/control.py
@@ -164,7 +164,7 @@ class USBControlEndpoint(Elaboratable):
 
 			# Create a display name for the handler...
 			name = handler.__class__.__name__
-			if hasattr(m.submodules, name):
+			if m.has_submodule(name):
 				name = f'{name}_{id(handler)}'
 
 			# ... and add it.

--- a/torii_usb/usb/usb2/device.py
+++ b/torii_usb/usb/usb2/device.py
@@ -297,7 +297,7 @@ class USBDevice(Elaboratable):
 
 			# Create a display name for the endpoint...
 			name = endpoint.__class__.__name__
-			if hasattr(m.submodules, name):
+			if m.has_submodule(name):
 				name = f'{name}_{id(endpoint)}'
 
 			# ... and add it, both as a submodule and to our multiplexer.

--- a/torii_usb/usb/usb3/device.py
+++ b/torii_usb/usb/usb3/device.py
@@ -165,7 +165,7 @@ class USBSuperSpeedDevice(Elaboratable):
 
 			# Create a display name for the endpoint...
 			name = endpoint.__class__.__name__
-			if hasattr(m.submodules, name):
+			if m.has_submodule(name):
 				name = f'{name}_{id(endpoint)}'
 
 			# ... and add it, both as a submodule and to our multiplexer.

--- a/torii_usb/usb/usb3/endpoints/control.py
+++ b/torii_usb/usb/usb3/endpoints/control.py
@@ -118,7 +118,7 @@ class USB3ControlEndpoint(Elaboratable):
 
 			# Create a display name for the handler...
 			name = handler.__class__.__name__
-			if hasattr(m.submodules, name):
+			if m.has_submodule(name):
 				name = f'{name}_{id(handler)}'
 
 			# ... and add it.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR fixes the issues that were noted in shrine-maiden-heavy-industries/torii-hdl#139 and subsequently fixed in shrine-maiden-heavy-industries/torii-hdl#141 by replacing all the `hasattr(m.submodule, ...)` calls with `m.has_submodule(...)`

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii USB [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii USB and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-usb/blob/main/CONTRIBUTING.md#ai-usage-policy
